### PR TITLE
Add bindings for QML

### DIFF
--- a/HttpServer/qmldir
+++ b/HttpServer/qmldir
@@ -1,0 +1,2 @@
+module HttpServer
+plugin qhttpserver ../lib

--- a/examples/bodydata/bodydata.cpp
+++ b/examples/bodydata/bodydata.cpp
@@ -50,7 +50,7 @@ void Responder::accumulate(const QByteArray &data)
 
 void Responder::reply()
 {
-    m_resp->end(QString("</p></body></html>").toAscii());
+    m_resp->end(QString("</p></body></html>").toLatin1());
 }
 
 BodyData::BodyData()

--- a/examples/greeting/greeting.cpp
+++ b/examples/greeting/greeting.cpp
@@ -26,7 +26,7 @@ void Greeting::handle(QHttpRequest *req, QHttpResponse *resp)
         QString name = exp.capturedTexts()[1];
 
         QString reply = tr("<html><head><title>Greeting App</title></head><body><h1>Hello %1!</h1></body></html>");
-        resp->end(reply.arg(name).toAscii());
+        resp->end(reply.arg(name).toLatin1());
     }
     else
     {

--- a/examples/qml/app.qml
+++ b/examples/qml/app.qml
@@ -1,0 +1,32 @@
+// Run with `qmlscene -I ../.. app.qml`
+
+import QtQuick 2.0
+import HttpServer 1.0
+
+Item {
+    width: 300; height: 200
+
+    HttpServer {
+        id: server
+        Component.onCompleted: listen("127.0.0.1", 5000)
+        
+        onNewRequest: { // request, response
+            response.writeHead(200)
+            response.write("<h1>Request properties</h1><ul>")
+            response.write("<li>remoteAddress: " + request.remoteAddress + "</li>")
+            response.write("<li>remotePort: " + request.remotePort + "</li>")
+            response.write("<li>method: " + request.method + "</li>")
+            response.write("<li>url: " + request.url + "</li>")
+            response.write("<li>path: " + request.path + "</li>")
+            response.write("<li>httpVersion: " + request.httpVersion + "</li>")
+            response.end()
+        }
+    }
+
+    Text {
+        anchors.centerIn: parent
+        text: "Serving at <a href='http://localhost:5000'>localhost:5000</a>"
+        onLinkActivated: Qt.openUrlExternally(link)
+    }
+}
+

--- a/src/httpserverplugin.cpp
+++ b/src/httpserverplugin.cpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2013 Robert Schroll <rschroll@gmail.com>
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE. 
+ */
+
+#include "httpserverplugin.h"
+#include "qhttpserver.h"
+#include "qhttprequest.h"
+#include "qhttpresponse.h"
+#include <qqml.h>
+
+void HttpServerPlugin::registerTypes(const char *uri)
+{
+    qmlRegisterType<QHttpServer>(uri, 1, 0, "HttpServer");
+    qmlRegisterUncreatableType<QHttpRequest>(uri, 1, 0, "HttpRequest", "Do not create HttpRequest directly");
+    qmlRegisterUncreatableType<QHttpResponse>(uri, 1, 0, "HttpResponse", "Do not create HttpResponse directly");
+}

--- a/src/httpserverplugin.h
+++ b/src/httpserverplugin.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2013 Robert Schroll <rschroll@gmail.com>
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE. 
+ */
+
+#ifndef HTTPSERVERPLUGIN_H
+#define HTTPSERVERPLUGIN_H
+
+#include <QQmlExtensionPlugin>
+
+class HttpServerPlugin : public QQmlExtensionPlugin
+{
+    Q_OBJECT
+    Q_PLUGIN_METADATA(IID "com.github.nikhilm.HttpServer")
+
+public:
+    void registerTypes(const char *uri);
+};
+
+#endif // HTTPSERVERPLUGIN_H

--- a/src/qhttpconnection.cpp
+++ b/src/qhttpconnection.cpp
@@ -154,7 +154,7 @@ int QHttpConnection::Url(http_parser *parser, const char *at, size_t length)
     QHttpConnection *theConnection = (QHttpConnection *)parser->data;
     Q_ASSERT(theConnection->m_request);
 
-    QString url = QString::fromAscii(at, length);
+    QString url = QString::fromLatin1(at, length);
     theConnection->m_request->setUrl(QUrl(url));
     return 0;
 }
@@ -177,7 +177,7 @@ int QHttpConnection::HeaderField(http_parser *parser, const char *at, size_t len
         theConnection->m_currentHeaderValue = QString();
     }
 
-    QString fieldSuffix = QString::fromAscii(at, length);
+    QString fieldSuffix = QString::fromLatin1(at, length);
     theConnection->m_currentHeaderField += fieldSuffix;
     return 0;
 }
@@ -187,7 +187,7 @@ int QHttpConnection::HeaderValue(http_parser *parser, const char *at, size_t len
     QHttpConnection *theConnection = (QHttpConnection *)parser->data;
     Q_ASSERT(theConnection->m_request);
 
-    QString valueSuffix = QString::fromAscii(at, length);
+    QString valueSuffix = QString::fromLatin1(at, length);
     theConnection->m_currentHeaderValue += valueSuffix;
     return 0;
 }

--- a/src/qhttpconnection.cpp
+++ b/src/qhttpconnection.cpp
@@ -97,6 +97,11 @@ void QHttpConnection::flush()
     m_socket->flush();
 }
 
+void QHttpConnection::disconnectFromHost()
+{
+    m_socket->disconnectFromHost();
+}
+
 /********************
  * Static Callbacks *
  *******************/
@@ -132,6 +137,7 @@ int QHttpConnection::HeadersComplete(http_parser *parser)
         response->m_keepAlive = false;
 
     connect(theConnection, SIGNAL(destroyed()), response, SLOT(connectionClosed()));
+    connect(response, SIGNAL(done()), theConnection, SLOT(disconnectFromHost()));
 
     // we are good to go!
     emit theConnection->newRequest(theConnection->m_request, response);

--- a/src/qhttpconnection.h
+++ b/src/qhttpconnection.h
@@ -46,6 +46,9 @@ public:
     void write(const QByteArray &data);
     void flush();
 
+public slots:
+    void disconnectFromHost();
+
 signals:
     void newRequest(QHttpRequest*, QHttpResponse*);
 

--- a/src/qhttpresponse.cpp
+++ b/src/qhttpresponse.cpp
@@ -101,7 +101,7 @@ void QHttpResponse::writeHeaders()
         }
         //TODO: Expect case
 
-        writeHeader(name.toAscii(), value.toAscii());
+        writeHeader(name.toLatin1(), value.toLatin1());
     }
 
     if( !m_sentConnectionHeader )
@@ -140,7 +140,7 @@ void QHttpResponse::writeHead(int status)
 
     if( m_headerWritten ) return;
 
-    m_connection->write(QString("HTTP/1.1 %1 %2\r\n").arg(status).arg(STATUS_CODES[status]).toAscii());
+    m_connection->write(QString("HTTP/1.1 %1 %2\r\n").arg(status).arg(STATUS_CODES[status]).toLatin1());
     
     writeHeaders();
 

--- a/src/qhttpresponse.cpp
+++ b/src/qhttpresponse.cpp
@@ -177,9 +177,10 @@ void QHttpResponse::end(const QString &data)
     if(m_finished) {
       return;
     }
-    m_finished = true;
 
     write(data);
+
+    m_finished = true;
 
     emit done();
     deleteLater();

--- a/src/qhttpresponse.h
+++ b/src/qhttpresponse.h
@@ -103,7 +103,7 @@ public slots:
      * code. Any headers should be set before this
      * is called.
      */
-    void writeHead(int status);
+    Q_INVOKABLE void writeHead(int status);
 
     /*!
      * Write the block of data to the client.
@@ -112,13 +112,13 @@ public slots:
      * writeHead() has to be called before write(), otherwise the call will
      * fail.
      */
-    void write(const QByteArray &data);
+    Q_INVOKABLE void write(const QByteArray &data);
 
     /*!
      * Write a QString instead of a QByteArray.
      * \see write(const QByteArray &);
      */
-    void write(const QString &data);
+    Q_INVOKABLE void write(const QString &data);
 
     /*!
      * End the response. Data will be flushed
@@ -129,12 +129,12 @@ public slots:
      * This will emit done() and queue this object
      * for deletion. For details see \ref memorymanagement
      */
-    void end(const QString &data=QString());
+    Q_INVOKABLE void end(const QString &data=QString());
 
     /*!
      * Set a response header @c field to @c value
      */
-    void setHeader(const QString &field, const QString &value);
+    Q_INVOKABLE void setHeader(const QString &field, const QString &value);
 
 signals:
     /*!

--- a/src/qhttpserver.cpp
+++ b/src/qhttpserver.cpp
@@ -114,6 +114,11 @@ bool QHttpServer::listen(const QHostAddress &address, quint16 port)
     return m_tcpServer->listen(address, port);
 }
 
+bool QHttpServer::listen(const QString &address, quint16 port)
+{
+    return listen(QHostAddress(address), port);
+}
+
 bool QHttpServer::listen(quint16 port)
 {
     return listen(QHostAddress::Any, port);

--- a/src/qhttpserver.h
+++ b/src/qhttpserver.h
@@ -124,18 +124,29 @@ public:
      * all interfaces which means the server can be accessed from anywhere.
      * \param port Port number on which the server should run.
      * \return true if the server was started successfully, false otherwise.
-     * \sa listen(quint16)
+     * \sa listen(quint16), listen(const QString&, quint16)
      */
     bool listen(const QHostAddress &address = QHostAddress::Any, quint16 port=0);
+
+    /*!
+     * Start the server bound to the @c address and @c port.
+     * This function returns immediately!
+     *
+     * \param address Address on which to listen to.
+     * \param port Port number on which the server should run.
+     * \return true if the server was started successfully, false otherwise.
+     * \sa listen(quint16), listen(const QHostAddress&, quint16)
+     */
+    Q_INVOKABLE bool listen(const QString &address, quint16 port=0);
 
     /*!
      * Starts the server on @c port listening on all interfaces.
      *
      * \param port Port number on which the server should run.
      * \return true if the server was started successfully, false otherwise.
-     * \sa listen(const QHostAddress&, quint16)
+     * \sa listen(const QHostAddress&, quint16), listen(const QString&, quint16)
      */
-    bool listen(quint16 port);
+    Q_INVOKABLE bool listen(quint16 port);
 
     /*!
      * Stop listening for connections

--- a/src/src.pro
+++ b/src/src.pro
@@ -1,11 +1,13 @@
 include(../qhttpserver.pri)
 QHTTPSERVER_BASE = ..
 TEMPLATE = lib
+CONFIG += plugin
 
 TARGET = qhttpserver
 VERSION = 0.1.0
 
 QT += network
+QT += qml
 QT -= gui
 
 CONFIG += dll debug
@@ -14,7 +16,7 @@ INCLUDEPATH += $$QHTTPSERVER_BASE/http-parser
 
 PRIVATE_HEADERS += $$QHTTPSERVER_BASE/http-parser/http_parser.h qhttpconnection.h
 
-PUBLIC_HEADERS += qhttpserver.h qhttprequest.h qhttpresponse.h
+PUBLIC_HEADERS += qhttpserver.h qhttprequest.h qhttpresponse.h httpserverplugin.h
 
 HEADERS = $$PRIVATE_HEADERS $$PUBLIC_HEADERS
 SOURCES = *.cpp $$QHTTPSERVER_BASE/http-parser/http_parser.c


### PR DESCRIPTION
These commits add support for using QHttpServer from QML, which is either awesome or insane.  I'm undecided as to which, but if you think it's the former, here's a pull request.

The first two commits are necessary to get everything working with Qt5.  If you'd prefer, I could split them out into a separate pull request.

There probably needs to be something done to get the QML bindings to install.  I'm new to Qt, so I don't know what that is.  Right now, it will run from the build directory just fine.