### PR TITLE
Fix missing headers when installing

### DIFF
--- a/src/src.pro
+++ b/src/src.pro
@@ -14,7 +14,7 @@ INCLUDEPATH += $$QHTTPSERVER_BASE/http-parser
 
 PRIVATE_HEADERS += $$QHTTPSERVER_BASE/http-parser/http_parser.h qhttpconnection.h
 
-PUBLIC_HEADERS += qhttpserver.h qhttprequest.h qhttpresponse.h
+PUBLIC_HEADERS += qhttpserver.h qhttprequest.h qhttpresponse.h qhttpserverapi.h qhttpserverfwd.h
 
 HEADERS = $$PRIVATE_HEADERS $$PUBLIC_HEADERS
 SOURCES = *.cpp $$QHTTPSERVER_BASE/http-parser/http_parser.c


### PR DESCRIPTION
I added qhttpserverapi.h and qhttpserverfwd.h to PUBLIC_HEADERS in src.pro to fix installation. These headers are required by other installed headers but by default they are not installed.
