### PR TITLE
Build the library with optimizations by default

### DIFF
--- a/src/src.pro
+++ b/src/src.pro
@@ -8,7 +8,7 @@ VERSION = 0.1.0
 QT += network
 QT -= gui
 
-CONFIG += dll debug
+CONFIG += dll
 
 INCLUDEPATH += $$QHTTPSERVER_BASE/http-parser
 


### PR DESCRIPTION
I think it would be better to build the library without debug symbols and with optimizations by default.
