### PR TITLE
Fixed a memory leak in QHttpConnection

### DIFF
--- a/src/qhttpconnection.cpp
+++ b/src/qhttpconnection.cpp
@@ -150,6 +150,7 @@ int QHttpConnection::HeadersComplete(http_parser *parser)
 
     connect(theConnection, SIGNAL(destroyed()), response, SLOT(connectionClosed()));
     connect(response, SIGNAL(done()), theConnection, SLOT(responseDone()));
+    connect(response, SIGNAL(destroyed()), theConnection, SLOT(deleteLater()));
 
     // we are good to go!
     emit theConnection->newRequest(theConnection->m_request, response);


### PR DESCRIPTION
There's a memory leak in QHttpConnection which leaks 24-28kB per request. For some reason the connection object is not cleaned up after the connection has been handled even though connection::socketDisconnected() calls deleteLater(). I was able to fix this by connecting response::destroyed() to connection::deleteLater().

Maybe you have a better idea of how this should be fixed.
