### PR TITLE
Evaluate http_parser::errno after running http_parser_execute

### DIFF
--- a/src/qhttpconnection.cpp
+++ b/src/qhttpconnection.cpp
@@ -105,6 +105,11 @@ void QHttpConnection::parseRequest()
     while (m_socket->bytesAvailable()) {
         QByteArray arr = m_socket->readAll();
         http_parser_execute(m_parser, m_parserSettings, arr.constData(), arr.size());
+        http_errno err = HTTP_PARSER_ERRNO(m_parser);
+        if (err != HPE_OK) {
+            qWarning() << "QHttpConnection::parseRequest()" << http_errno_name(err) << http_errno_description(err);
+            m_socket->abort();
+        }
     }
 }
 

--- a/src/qhttpserverfwd.h
+++ b/src/qhttpserverfwd.h
@@ -38,8 +38,10 @@ class QHttpRequest;
 class QHttpResponse;
 
 // Qt
+QT_BEGIN_NAMESPACE
 class QTcpServer;
 class QTcpSocket;
+QT_END_NAMESPACE
 
 // http_parser
 struct http_parser_settings;


### PR DESCRIPTION
The current behavior of broken HTTP requests is unsatisfactory, as the connection stays open indefinitely.  This commit evaluates the ```http_parser::errno``` value after ```http_parser_execute()```.

New behavior is to instantly close the current connection, if the parser exits with an error instead of timing-out.

Before (notice the space before ```GET```:
```
~/Repos/qhttpserver$ telnet localhost 8080
Trying 127.0.0.1...
Connected to localhost.
Escape character is '^]'.
 GET / HTTP/1.0

sdfsfsa

foo

^C^C^C^]
telnet> Connection closed.
```

After:
```
~/Repos/qhttpserver$ telnet localhost 8080
Trying 127.0.0.1...
Connected to localhost.
Escape character is '^]'.
 GET / HTTP/1.0
Connection closed by foreign host.
```

Although it is still not perfect now. For example, the Apace replies with a ```HTTP/1.1 400 Bad Request``` response. 

