### PR TITLE
Fixed socket deletion error

### DIFF
--- a/src/qhttpconnection.cpp
+++ b/src/qhttpconnection.cpp
@@ -73,8 +73,8 @@ QHttpConnection::~QHttpConnection()
 void QHttpConnection::socketDisconnected()
 {
     invalidateRequest();
-	m_socket->deleteLater();
-	deleteLater();
+    m_socket->deleteLater();
+    deleteLater();
 }
 
 void QHttpConnection::invalidateRequest()

--- a/src/qhttpconnection.cpp
+++ b/src/qhttpconnection.cpp
@@ -61,7 +61,6 @@ QHttpConnection::QHttpConnection(QTcpSocket *socket, QObject *parent)
 
 QHttpConnection::~QHttpConnection()
 {
-    delete m_socket;
     m_socket = 0;
 
     free(m_parser);
@@ -73,8 +72,9 @@ QHttpConnection::~QHttpConnection()
 
 void QHttpConnection::socketDisconnected()
 {
-    deleteLater();
     invalidateRequest();
+	m_socket->deleteLater();
+	deleteLater();
 }
 
 void QHttpConnection::invalidateRequest()


### PR DESCRIPTION
Deleting the socket in the destructor can cause a crash when shutting down the app. By moving it to the `socketDisconnected`and deleting it with `deleteLater` fixed the issue.
