### PR TITLE
Fix paths double encoding

### DIFF
--- a/src/qhttpconnection.cpp
+++ b/src/qhttpconnection.cpp
@@ -148,7 +148,7 @@ QUrl createUrl(const char *urlData, const http_parser_url &urlInfo)
     url.setScheme(CHECK_AND_GET_FIELD(urlData, urlInfo, UF_SCHEMA));
     url.setHost(CHECK_AND_GET_FIELD(urlData, urlInfo, UF_HOST));
     // Port is dealt with separately since it is available as an integer.
-    url.setPath(CHECK_AND_GET_FIELD(urlData, urlInfo, UF_PATH));
+    url.setPath(CHECK_AND_GET_FIELD(urlData, urlInfo, UF_PATH), QUrl::TolerantMode);
 #if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
     url.setQuery(CHECK_AND_GET_FIELD(urlData, urlInfo, UF_QUERY));
 #else


### PR DESCRIPTION
QUrl::setPath used by default 'DecodedMode' of the input path
http://doc.qt.io/qt-5/qurl.html#setPath
unlike setQuery setFragment setUserInfo
When the path already contains the URL-encoded characters they will be encoded again